### PR TITLE
docs: fix enqueue example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ use Kucrut\Vite;
 
 add_action( 'wp_enqueue_scripts', function (): void {
 	Vite\enqueue_asset(
-		__DIR__ . 'js/dist',
+		__DIR__ . '/js/dist',
 		'js/src/main.ts',
 		[
 			'handle' => 'my-script-handle',


### PR DESCRIPTION
`__DIR__` doesn't have a trailing slash. so we need to add it here.