### PR TITLE
Fix error in enqueue_asset README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ use Kucrut\Vite;
 
 add_action( 'wp_enqueue_scripts', function (): void {
 	Vite\enqueue_asset(
-		__DIR__ . 'js/dist',
+		__DIR__ . '/js/dist',
 		'js/src/main.ts',
 		[
 			'handle' => 'my-script-handle',


### PR DESCRIPTION
I copied this example to my project and it wasn't working. Only after I set up xdebug did I notice the issue, that the path concatenation was the problem. Took me a few hours to figure out such a small fix lol.