### PR TITLE
Improve dev_server plugin

### DIFF
--- a/.changeset/neat-seals-explain.md
+++ b/.changeset/neat-seals-explain.md
@@ -1,0 +1,5 @@
+---
+'@kucrut/vite-for-wp': minor
+---
+
+Accept options in dev_server, prioritise dev manifest over build one in PHP helper.

--- a/src/exports/plugins/dev-server.js
+++ b/src/exports/plugins/dev-server.js
@@ -75,12 +75,6 @@ export function dev_server( options = {} ) {
 				manifest_dir = build.outDir;
 			}
 
-			const prod_manifest_file = build.outDir + '/manifest.json';
-
-			// Remove build manifest as the PHP helper uses it to determine
-			// which manifest to load when enqueueing assets.
-			fs.rmSync( prod_manifest_file, { force: true } );
-
 			const data = {
 				base,
 				origin: server.origin,

--- a/src/exports/plugins/dev-server.js
+++ b/src/exports/plugins/dev-server.js
@@ -22,6 +22,8 @@ import { choose_port } from '../utils/choose-port.js';
  */
 export function dev_server( options = {} ) {
 	const plugins_to_check = [ 'vite:react-refresh' ];
+	/** @type {import('vite').ResolvedConfig} */
+	let resolved_config;
 	/** @type {string} */
 	let dev_manifest_data;
 	/** @type {string} */
@@ -69,10 +71,10 @@ export function dev_server( options = {} ) {
 		},
 
 		configResolved( config ) {
-			const { base, build, plugins, server } = config;
+			resolved_config = config;
 
 			if ( ! manifest_dir ) {
-				manifest_dir = build.outDir;
+				manifest_dir = config.build.outDir;
 			}
 
 			const data = {

--- a/src/exports/plugins/dev-server.js
+++ b/src/exports/plugins/dev-server.js
@@ -1,6 +1,6 @@
-import fs from 'node:fs';
 import { choose_port } from '../utils/choose-port.js';
 import { join } from 'node:path';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 
 /**
  * Dev Server Options
@@ -82,14 +82,14 @@ export function dev_server( options = {} ) {
 			} );
 
 			const manifest_dir = options.manifest_dir || build.outDir;
-			manifest_file = join( manifest_dir, '/vite-dev-server.json' );
+			manifest_file = join( manifest_dir, 'vite-dev-server.json' );
 
-			fs.mkdirSync( manifest_dir, { recursive: true } );
-			fs.writeFileSync( manifest_file, data, 'utf8' );
+			mkdirSync( manifest_dir, { recursive: true } );
+			writeFileSync( manifest_file, data, 'utf8' );
 		},
 
 		buildEnd() {
-			fs.rmSync( manifest_file, { force: true } );
+			rmSync( manifest_file, { force: true } );
 		},
 	};
 }

--- a/src/exports/plugins/dev-server.js
+++ b/src/exports/plugins/dev-server.js
@@ -2,12 +2,25 @@ import fs from 'node:fs';
 import { choose_port } from '../utils/choose-port.js';
 
 /**
+ * Dev Server Options
+ *
+ * @typedef DevServerOptions
+ *
+ * @property {string=} manifest_dir Path to directory where the dev server manifest should be stored. Defaults to the value of `build.outDir` option.
+ */
+
+/**
  * Dev server plugin
  *
- * @type {() => import('vite').Plugin}
+ * @since 0.1.0
+ * @since 0.8.0 Accept options.
+ *
+ * @type {(options?: DevServerOptions) => import('vite').Plugin}
+ *
+ * @param {DevServerOptions=} options Plugin options.
  * @return {import('vite').Plugin} Plugin object.
  */
-export function dev_server() {
+export function dev_server( options = {} ) {
 	const plugins_to_check = [ 'vite:react-refresh' ];
 	/** @type {string} */
 	let dev_manifest_data;

--- a/src/exports/plugins/dev-server.js
+++ b/src/exports/plugins/dev-server.js
@@ -27,6 +27,8 @@ export function dev_server( options = {} ) {
 	/** @type {string} */
 	let dev_manifest_file;
 
+	let { manifest_dir } = options;
+
 	return {
 		apply: 'serve',
 		name: 'v4wp:dev-server',
@@ -68,6 +70,11 @@ export function dev_server( options = {} ) {
 
 		configResolved( config ) {
 			const { base, build, plugins, server } = config;
+
+			if ( ! manifest_dir ) {
+				manifest_dir = build.outDir;
+			}
+
 			const prod_manifest_file = build.outDir + '/manifest.json';
 
 			// Remove build manifest as the PHP helper uses it to determine

--- a/src/exports/plugins/dev-server.js
+++ b/src/exports/plugins/dev-server.js
@@ -88,14 +88,8 @@ export function dev_server( options = {} ) {
 			fs.writeFileSync( manifest_file, data, 'utf8' );
 		},
 
-		configureServer( { httpServer } ) {
-			if ( ! httpServer ) {
-				return;
-			}
-
-			httpServer.on( 'close', () => {
-				fs.rmSync( manifest_file, { force: true } );
-			} );
+		buildEnd() {
+			fs.rmSync( manifest_file, { force: true } );
 		},
 	};
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,7 +21,16 @@ declare module '@kucrut/vite-for-wp' {
 }
 
 declare module '@kucrut/vite-for-wp/plugins' {
-	export function dev_server(): import('vite').Plugin;
+	export function dev_server(options?: DevServerOptions): import('vite').Plugin;
+	/**
+	 * Dev Server Options
+	 */
+	type DevServerOptions = {
+		/**
+		 * Path to directory where the dev server manifest should be stored. Defaults to the value of `build.outDir` option.
+		 */
+		manifest_dir?: string | undefined;
+	};
 	export function wp_scripts(options?: WPScriptsOptions): Plugin;
 	type Plugin = import('vite').PluginOption;
 	/**

--- a/types/index.d.ts.map
+++ b/types/index.d.ts.map
@@ -18,5 +18,5 @@
 		null,
 		null
 	],
-	"mappings": ";;;aAG6BA,UAAUA;aACyCC,KAAKA;aACrBC,MAAMA;aAC3BC,MAAMA;;;;;;;;;;;;;;;;;;;MCFNA,MAAMA;;;;MCCrCC,gBAAgBA"
+	"mappings": ";;;aAG6BA,UAAUA;aACyCC,KAAKA;aACrBC,MAAMA;aAC3BC,MAAMA;;;;;;;;;;;;;;;;;;;;;;;;;;;;MCFNA,MAAMA;;;;MCCrCC,gBAAgBA"
 }

--- a/vite-for-wp.php
+++ b/vite-for-wp.php
@@ -31,7 +31,7 @@ function get_manifest( string $manifest_dir ): object {
 	// Avoid repeatedly opening & decoding the same file.
 	static $manifests = [];
 
-	$file_names = [ 'manifest', $dev_manifest ];
+	$file_names = [ $dev_manifest, 'manifest' ];
 
 	foreach ( $file_names as $file_name ) {
 		$is_dev = $file_name === $dev_manifest;


### PR DESCRIPTION
JS:

* accept options object in `dev_server` plugin to set manifest directory
* create dev server manifest via `buildStart` hook
* delete dev server manifest via `buildEnd` hook
* leave build manifest alone.

PHP:

* prioritise dev server manifest over build one.