### PR TITLE
Enhancement for RefreshRuntime injecting

### DIFF
--- a/vite-for-wp.php
+++ b/vite-for-wp.php
@@ -172,9 +172,10 @@ function inject_react_refresh_preamble_script( object $manifest ): void {
 	}
 
 	$script_position = 'after';
+	$script_idx = $script_position === 'after' ? 1 : 0;
 	$inline_scripts = wp_scripts()->get_data( VITE_CLIENT_SCRIPT_HANDLE, $script_position );
 
-	if ( $inline_scripts[$script_position] && str_contains( $inline_scripts[$script_position], 'window.__vite_plugin_react_preamble_installed__' ) ) {
+	if ( $inline_scripts && $inline_scripts[ $script_idx ] && str_contains( $inline_scripts[ $script_idx ], 'window.__vite_plugin_react_preamble_installed__' ) ) {
 		return;
 	}
 

--- a/vite-for-wp.php
+++ b/vite-for-wp.php
@@ -167,18 +167,18 @@ function register_vite_client_script( object $manifest ): void {
  * @return void
  */
 function inject_react_refresh_preamble_script( object $manifest ): void {
-	static $is_react_refresh_preamble_printed = false;
-
-	if ( $is_react_refresh_preamble_printed ) {
-		return;
-	}
-
 	if ( ! in_array( 'vite:react-refresh', $manifest->data->plugins, true ) ) {
 		return;
 	}
 
-	$react_refresh_script_src = generate_development_asset_src( $manifest, '@react-refresh' );
 	$script_position = 'after';
+	$inline_scripts = wp_scripts()->get_data( VITE_CLIENT_SCRIPT_HANDLE, $script_position );
+
+	if ( $inline_scripts[$script_position] && str_contains( $inline_scripts[$script_position], 'window.__vite_plugin_react_preamble_installed__' ) ) {
+		return;
+	}
+
+	$react_refresh_script_src = generate_development_asset_src( $manifest, '@react-refresh' );
 	$script = <<< EOS
 import RefreshRuntime from "{$react_refresh_script_src}";
 RefreshRuntime.injectIntoGlobalHook(window);
@@ -198,8 +198,6 @@ EOS;
 			return $attributes;
 		}
 	);
-
-	$is_react_refresh_preamble_printed = true;
 }
 
 /**


### PR DESCRIPTION
The current implementation relies on the static variable to inject RefreshRuntime only once in dev mode. This fails in the context of WP Admin (e.g. when developing a block and wanting to preview how it looks in the editor) since the code needs to be injected both in the page and in the editor iframe. As a result, the block is not detected at all.

This PR addresses the problem by checking for the injected code presence instead.

The behavior resulting from this update when editing the block source code is a bit weird (the page refreshes, twice), but I believe this is a better option than switching off the dev server & build assets to preview something in the admin.