### PR TITLE
Consider the client root directory in the dev server path

### DIFF
--- a/src/exports/plugins/dev-server.js
+++ b/src/exports/plugins/dev-server.js
@@ -72,7 +72,7 @@ export function dev_server( options = {} ) {
 		},
 
 		buildStart() {
-			const { base, build, plugins, server } = resolved_config;
+			const { base, build, plugins, server, root } = resolved_config;
 
 			const data = JSON.stringify( {
 				base,
@@ -81,7 +81,8 @@ export function dev_server( options = {} ) {
 				plugins: plugins_to_check.filter( i => plugins.some( ( { name } ) => name === i ) ),
 			} );
 
-			const manifest_dir = options.manifest_dir || build.outDir;
+			const buildDir = root.replace(/\/+$/, '') + '/' + build.outDir.replace(/^\/+/, '');
+			const manifest_dir = options.manifest_dir || buildDir;
 			manifest_file = join( manifest_dir, 'vite-dev-server.json' );
 
 			mkdirSync( manifest_dir, { recursive: true } );


### PR DESCRIPTION
I have a vite config that looks like this:

```js
export default {
	root: 'client',
	plugins: [
		v4wp( {
			input: {
				settings: '/Page/Admin/Settings.tsx',
			},
			outDir: 'build',
		} ),
		react(),
	]
};
```

When running `npm run build`, it would respect the root `client` path and output the build directory in the client directory. But when running `npm run dev` the dev server doesn't account for the `client` root and outputs the build at the same level of the client directory.