### PR TITLE
Fix: Preserve server.origin in Vite Config and Improve StrictPort Handling

### DIFF
--- a/src/exports/plugins/dev-server.js
+++ b/src/exports/plugins/dev-server.js
@@ -66,7 +66,7 @@ export function dev_server( options = {} ) {
 
       		const finalOrigin =
 				typeof origin === 'string'
-				? origin
+				? normalizeOriginWithPort(origin, port)
 				: `${server_protocol}://${host}:${port}`
 
 			// Use user-defined values if they exist, otherwise use the defaults
@@ -142,4 +142,36 @@ async function is_port_in_use(port, host = '127.0.0.1') {
 		
 		server.listen(port, host);
 	});
+}
+
+/**
+ * Check origin validity and add port if missing.
+ * Ensures the origin does not end with a slash.
+ * @author David Mussard <david.mussard@gmail.com>
+ *
+ * @param {string} origin - The origin to normalize
+ * @param {number} port - The port to add if missing
+ * @returns {string} - The normalized origin
+ */
+function normalizeOriginWithPort(origin, port) {
+	try {
+		const url = new URL(origin);
+		// If the URL has no port, add the one provided
+		if (!url.port) {
+			url.port = port;
+		}
+		
+		let normalizedOrigin = url.toString();
+		
+		// Remove trailing slash if it exists
+		if (normalizedOrigin.endsWith('/')) {
+			normalizedOrigin = normalizedOrigin.slice(0, -1);
+		}
+		
+		return normalizedOrigin;
+	} catch (err) {
+		// If the URL is invalid, return it as is
+		console.warn(`Invalid origin URL: ${origin}`);
+		return origin;
+	}
 }

--- a/src/exports/plugins/dev-server.js
+++ b/src/exports/plugins/dev-server.js
@@ -1,6 +1,7 @@
 import { choose_port } from '../utils/choose-port.js';
 import { join } from 'node:path';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import net from 'node:net';
 
 /**
  * Dev Server Options
@@ -32,9 +33,16 @@ export function dev_server( options = {} ) {
 		apply: 'serve',
 		name: 'v4wp:dev-server',
 
-		async config( config ) {
-			const { server = {} } = config;
-			let { host = 'localhost', port = 5173, ...server_config } = server;
+		async config( userConfig ) {
+			const userServer = userConfig.server ?? {}
+
+			let {
+				host = 'localhost',
+				port = 5173,
+				origin,            // If origin is not set, it will be generated from host and port
+				hmr: userHmr = {},
+				...server_config   // https, headers, strictPort, etc.
+			} = userServer
 
 			// We need actual host name or IP address for choose_port() to work.
 			if ( typeof host === 'boolean' ) {
@@ -44,25 +52,39 @@ export function dev_server( options = {} ) {
 			const hmr_protocol = server_config.https ? 'wss' : 'ws';
 			const server_protocol = server_config.https ? 'https' : 'http';
 
-			// Ensure chosen port is available because we need to enable strictPort below.
-			// If the chosen port is already in use, a free one will be selected.
-			port = await choose_port( { host, port } );
+			// Check if strictPort is enabled and if the chosen port is already in use.
+			if (server_config.strictPort) {
+				const inUse = await is_port_in_use(port, host);
+				if (inUse) {
+					throw new Error(`Port ${port} already in use on ${host}`);
+				}
+			} else {
+				// Ensure chosen port is available because we need to enable strictPort below.
+				// If the chosen port is already in use, a free one will be selected.
+				port = await choose_port( { host, port } );
+			}
 
-			// This will be used by the PHP helper.
-			const origin = `${ server_protocol }://${ host }:${ port }`;
+      		const finalOrigin =
+				typeof origin === 'string'
+				? origin
+				: `${server_protocol}://${host}:${port}`
+
+			// Use user-defined values if they exist, otherwise use the defaults
+			const finalHmr = {
+				...userHmr,
+				port: userHmr.port ?? port,
+				host: userHmr.host ?? host,
+				protocol: userHmr.protocol ?? hmr_protocol,
+			}
 
 			return {
 				server: {
 					...server_config,
 					host,
-					origin,
+					origin: finalOrigin,
 					port,
 					strictPort: true,
-					hmr: {
-						port,
-						host,
-						protocol: hmr_protocol,
-					},
+					hmr: finalHmr,
 				},
 			};
 		},
@@ -92,4 +114,32 @@ export function dev_server( options = {} ) {
 			rmSync( manifest_file, { force: true } );
 		},
 	};
+}
+
+/**
+ * Check if port is busy.
+ * @author David Mussard <david.mussard@gmail.com>
+ * @param {number} port
+ * @param {string} host
+ * @returns {Promise<boolean>}
+ */
+async function is_port_in_use(port, host = '127.0.0.1') {
+	return new Promise((resolve) => {
+		const server = net.createServer();
+		
+		server.once('error', (err) => {
+			if (err.code === 'EADDRINUSE') {
+				resolve(true);  // Port is busy
+			} else {
+				resolve(false);
+			}
+		});
+		
+		server.once('listening', () => {
+			server.close();
+			resolve(false);  // Port is free
+		});
+		
+		server.listen(port, host);
+	});
 }


### PR DESCRIPTION
### **Description**  
This pull request fixes the issue where the `server.origin` option in `vite.config.js` is being overwritten by the plugin behavior in `@kucrut/vite-for-wp`. With this fix, the user-defined `origin` is respected, and if the port is missing, it will be automatically appended.  

Additionally, the `strictPort` option is now properly enforced: if enabled and the specified port is already in use, the server will throw an error instead of automatically selecting a different port.  

---

### **Changes Made**  
- Preserved the user-defined `server.origin` in the Vite configuration.  
- Implemented `normalizeOriginWithPort` to validate the `origin` and append the port if missing.  
- Enforced `strictPort` behavior to prevent automatic port switching when the desired port is occupied.  
- Improved HMR configuration handling to respect user-defined settings.  

---

### **How to Test**  

1. In your `vite.config.js`, set the following configuration:  

```
server: {
  host: '0.0.0.0', // Listen on all network interfaces
  https: {
    key: fs.readFileSync(process.env.SSL_LOCAL_PK),  // Path to SSL key
    cert: fs.readFileSync(process.env.SSL_LOCAL_CERT),  // Path to SSL cert
  },
  origin: 'https://example.com', // Port will be appended automatically if missing
  hmr: {
    protocol: 'wss', // HMR uses wss protocol
    host: 'example.com', // Dev server host (without protocol)
  },
  strictPort: true, // Enforce a specific port or throw an error if it's taken
}
```

2. Start the Vite dev server.  
3. If the specified port is in use and `strictPort` is enabled, the server should throw an error.  
4. Verify that the `origin` includes the correct port and no longer gets overwritten.  